### PR TITLE
[api] Limit number of return rows by one during matching operation

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -855,7 +855,7 @@ def match_identities(db, uuid, matcher):
 
     The function will search in the registry for similar identities to 'uuid'.
     The result will be a list matches containing unique identities objects.
-    This list will also include the given unique identity.
+    This list will not(!) include the given unique identity.
 
     The criteria used to check when an identity matches with another one
     is defined by 'matcher' parameter. This parameter is an instance
@@ -879,7 +879,8 @@ def match_identities(db, uuid, matcher):
         if not uid:
             raise NotFoundError(entity=uuid)
 
-        candidates = session.query(UniqueIdentity).all()
+        # Get all identities expect of the one requested one query above (uid)
+        candidates = session.query(UniqueIdentity).filter(UniqueIdentity.uuid != uuid).all()
 
         for candidate in candidates:
             if not matcher.match(uid, candidate):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1922,37 +1922,37 @@ class TestMatchIdentities(TestBaseCase):
         m1 = api.match_identities(self.db, 'John Smith', matcher)
         uids = get_uuids(m1)
 
-        self.assertListEqual(uids, ['John Smith', 'Smith J.'])
+        self.assertListEqual(uids, ['Smith J.'])
 
         # Smith J.
         m1 = api.match_identities(self.db, 'Smith J.', matcher)
         uids = get_uuids(m1)
 
-        self.assertListEqual(uids, ['John Smith', 'Smith J.'])
+        self.assertListEqual(uids, ['John Smith'])
 
         # John Doe
         m2 = api.match_identities(self.db, 'John Doe', matcher)
         uids = get_uuids(m2)
 
-        self.assertListEqual(uids, ['John Doe'])
+        self.assertListEqual(uids, [])
 
         # Jane Rae
         m3 = api.match_identities(self.db, 'Jane Rae', matcher)
         uids = get_uuids(m3)
 
-        self.assertListEqual(uids, ['Jane', 'Jane Rae', 'JRae'])
+        self.assertListEqual(uids, ['Jane', 'JRae'])
 
         # JRae
         m3 = api.match_identities(self.db, 'JRae', matcher)
         uids = get_uuids(m3)
 
-        self.assertListEqual(uids, ['Jane', 'Jane Rae', 'JRae'])
+        self.assertListEqual(uids, ['Jane', 'Jane Rae'])
 
         # Jane
         m3 = api.match_identities(self.db, 'Jane', matcher)
         uids = get_uuids(m3)
 
-        self.assertListEqual(uids, ['Jane', 'Jane Rae', 'JRae'])
+        self.assertListEqual(uids, ['Jane Rae', 'JRae'])
 
 
     def test_empty_registry(self):


### PR DESCRIPTION
This is a new PR based on https://github.com/MetricsGrimoire/sortinghat/pull/16.
The commits were squashed and rebased with master.

See https://github.com/MetricsGrimoire/sortinghat/pull/16 for details (discussion, purpose and so on)