### PR TITLE
Add support for Docker / Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7
+
+RUN pip install MYSQL-python SQLAlchemy Jinja2 python-dateutil
+
+ADD . /sortinghat
+
+WORKDIR /sortinghat
+
+RUN python setup.py install

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-Sorting Hat [![Build Status](https://travis-ci.org/MetricsGrimoire/sortinghat.svg?branch=master)](https://travis-ci.org/MetricsGrimoire/sortinghat) [![Coverage Status](https://img.shields.io/coveralls/MetricsGrimoire/sortinghat.svg)](https://coveralls.io/r/MetricsGrimoire/sortinghat?branch=master)
-===========
+# Sorting Hat [![Build Status](https://travis-ci.org/MetricsGrimoire/sortinghat.svg?branch=master)](https://travis-ci.org/MetricsGrimoire/sortinghat) [![Coverage Status](https://img.shields.io/coveralls/MetricsGrimoire/sortinghat.svg)](https://coveralls.io/r/MetricsGrimoire/sortinghat?branch=master)
 
 A tool to manage identities.
 
-Usage
------
+## Usage
+
 ```
 usage: sortinghat [--help] [-c <file>] [-u <user>] [-p <password>]
                   [--host <host>] [--port <port>] [-d <name>]
@@ -46,8 +45,7 @@ General options:
 Run 'sortinghat <command> --help' to get information about a specific command.
 ```
 
-Installation
--------------
+## Installation
 
 You can install sortinghat just by running setup.py script:
 
@@ -74,8 +72,7 @@ $ export PYTHONPATH=$PYTHONPATH:sortinghatdir
 
 You are ready to use sortinghat!
 
-Configuration
--------------
+## Configuration
 
 * Configure database parameters
 ```
@@ -89,8 +86,7 @@ Configuration
   $ sortinghat init <name>
 ```
 
-Basic commands
---------------
+## Basic commands
 
 * Add some unique identities
 ```
@@ -219,8 +215,7 @@ Basic commands
   $ sortinghat withdraw --from 2014-06-01 --to 2015-09-01 03e12d00e37fd45593c49a5a5a1652deca4cf302 Example
 ```
 
-Import / Export
----------------
+## Import / Export
 
 * Import data from a Sorting Hat JSON file
 ```
@@ -246,8 +241,7 @@ Import / Export
   $ sortinghat export --orgs sh_orgs.json
 ```
 
-Requirements
-------------
+## Requirements
 
 * Python >= 2.7 (3.x series not supported yet)
 * MySQL >= 5.5
@@ -255,7 +249,6 @@ Requirements
 * Jinja2 >= 2.7
 * python-dateutil >= 1.5
 
-License
--------
+## License
 
 Licensed under GNU General Public License (GPL), version 3 or later.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Run 'sortinghat <command> --help' to get information about a specific command.
 
 ## Installation
 
+### Native
+
 You can install sortinghat just by running setup.py script:
 
 ```
@@ -68,6 +70,28 @@ In `$PYHTONPATH`, you need to include sortinghat as well. If sortinghatdir is th
 
 ```
 $ export PYTHONPATH=$PYTHONPATH:sortinghatdir
+```
+
+You are ready to use sortinghat!
+
+### Docker
+
+Start a MySQL docker container for data storage:
+
+```
+$ docker run --name mysql \
+             -e MYSQL_USER=sortinghat \
+             -e MYSQL_PASSWORD=sortinghat \
+             -e MYSQL_ROOT_PASSWORD=sortinghat \
+             -d mysql
+```
+
+Run the sortinhat docker container in interactive mode:
+
+```
+$ docker run -i -t --rm \
+             --link mysql:mysql metricsgrimoire/sortinghat:latest \
+             /bin/bash
 ```
 
 You are ready to use sortinghat!

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ docker run --name mysql \
              -d mysql
 ```
 
-Run the sortinhat docker container in interactive mode:
+Run the sortinghat docker container in interactive mode:
 
 ```
 $ docker run -i -t --rm \

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You are ready to use sortinghat!
 
 Start a MySQL docker container for data storage:
 
-```
+```sh
 $ docker run --name mysql \
              -e MYSQL_USER=sortinghat \
              -e MYSQL_PASSWORD=sortinghat \
@@ -88,7 +88,7 @@ $ docker run --name mysql \
 
 Run the sortinghat docker container in interactive mode:
 
-```
+```sh
 $ docker run -i -t --rm \
              --link mysql:mysql metricsgrimoire/sortinghat:latest \
              /bin/bash

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You are ready to use sortinghat!
 
 * Configure database parameters
 ```
+  $ sortinghat config set db.host <mysql-host>
   $ sortinghat config set db.user <user>
   $ sortinghat config set db.password <password>
   $ sortinghat config set db.database <name>


### PR DESCRIPTION
This pull request add support for [Docker](https://www.docker.com/).
Adding support for Docker make sense in (minimum) two ways:

* Newcomers: It enables new people who are familiar with Docker to try out sortinghat really fast without installing python (+libs) and the other requirements on their system. Docker enables them a fast usable and isolated env.
* Extensions: Projects that depend on sortinghat can use this Dockerfile as a basement for their Dockerfile. One example is my project [andygrunwald/apihat](https://github.com/andygrunwald/apihat)

Docker provides a public docker registry called [Docker Hub](https://hub.docker.com/).
At this place open source projects can host the (pre build) docker images.
Next to this pull request i suggest to setup an automated build on DockerHub.
With offers the advantage that after every push the master branch is compiled into a latest docker image.
If a version of sortinghat will be tagged (and released) this version will be compiled into an image as well.

I am not able to set this build up, because i have no rights to the sortinghat repository.
Access rights + be able to setup a webhook is necessary for this.
How this can look like see [gitlab/gitlab-ce @ Docker Hub](https://hub.docker.com/r/gitlab/gitlab-ce/)

I raised this topic on the mailing list already: [[Metrics-grimoire] Docker and MetricsGrimoire](https://lists.libresoft.es/pipermail/metrics-grimoire/2015-November/002435.html).

/cc @jgbarah 