### PR TITLE
Add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ You are ready to use sortinghat!
 
 ## Configuration
 
-* Configure database parameters
+Set the database parameters via the `config` command:
+
 ```
   $ sortinghat config set db.host <mysql-host>
   $ sortinghat config set db.user <user>
@@ -112,7 +113,17 @@ You are ready to use sortinghat!
   $ sortinghat config set db.database <name>
 ```
 
-* Initialize database
+Alternatively you can set environment variables:
+
+```
+  $ export SORTINGHAT_DB_HOST=<mysql-host>
+  $ export SORTINGHAT_DB_USER=<user>
+  $ export SORTINGHAT_DB_PASSWORD=<password>
+  $ export SORTINGHAT_DB_DATABASE=<name>
+```
+
+After this initialize a new database:
+
 ```
   $ sortinghat init <name>
 ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Set the database parameters via the `config` command:
   $ sortinghat config set db.user <user>
   $ sortinghat config set db.password <password>
   $ sortinghat config set db.database <name>
+  $ sortinghat config set db.port <port>
 ```
 
 Alternatively you can set environment variables:
@@ -120,6 +121,7 @@ Alternatively you can set environment variables:
   $ export SORTINGHAT_DB_USER=<user>
   $ export SORTINGHAT_DB_PASSWORD=<password>
   $ export SORTINGHAT_DB_DATABASE=<name>
+  $ export SORTINGHAT_DB_PORT=<port>
 ```
 
 After this initialize a new database:

--- a/bin/sortinghat
+++ b/bin/sortinghat
@@ -139,7 +139,7 @@ def create_common_arguments_parser(defaults):
     group = parser.add_argument_group('General options')
     group.add_argument('-h', '--help', action='help',
                        help=argparse.SUPPRESS)
-    group.add_argument('-u', '--user', dest='user', default=os.getenv('SORTINGHAT_DB_USER', 'root1'),
+    group.add_argument('-u', '--user', dest='user', default=os.getenv('SORTINGHAT_DB_USER', 'root'),
                        help=argparse.SUPPRESS)
     group.add_argument('-p', '--password', dest='password', default=os.getenv('SORTINGHAT_DB_PASSWORD', ''),
                        help=argparse.SUPPRESS)

--- a/bin/sortinghat
+++ b/bin/sortinghat
@@ -24,7 +24,7 @@
 from __future__ import unicode_literals
 
 import argparse
-import os.path
+import os
 import sys
 
 try:
@@ -139,15 +139,15 @@ def create_common_arguments_parser(defaults):
     group = parser.add_argument_group('General options')
     group.add_argument('-h', '--help', action='help',
                        help=argparse.SUPPRESS)
-    group.add_argument('-u', '--user', dest='user', default='root',
+    group.add_argument('-u', '--user', dest='user', default=os.getenv('SORTINGHAT_DB_USER', 'root1'),
                        help=argparse.SUPPRESS)
-    group.add_argument('-p', '--password', dest='password', default='',
+    group.add_argument('-p', '--password', dest='password', default=os.getenv('SORTINGHAT_DB_PASSWORD', ''),
                        help=argparse.SUPPRESS)
-    group.add_argument('-d', '--database', dest='database',
+    group.add_argument('-d', '--database', dest=os.getenv('SORTINGHAT_DB_DATABASE', 'database'),
                        help=argparse.SUPPRESS)
-    group.add_argument('--host', dest='host', default='localhost',
+    group.add_argument('--host', dest='host', default=os.getenv('SORTINGHAT_DB_HOST', 'localhost'),
                        help=argparse.SUPPRESS)
-    group.add_argument('--port', dest='port', default='3306',
+    group.add_argument('--port', dest='port', default=os.getenv('SORTINGHAT_DB_PORT', '3306'),
                        help=argparse.SUPPRESS)
 
     # Command arguments


### PR DESCRIPTION
sortinghat depends currently on a config file in users home dir.
In terms of the 12 factor apps configuration settings should be applied as env vars as well.
See http://12factor.net/config

This pull request enables the configuration for the database via env vars.
All other configuration types (incl. default values) are still supported.

This env vars are supported:
* `SORTINGHAT_DB_USER`
* `SORTINGHAT_DB_PASSWORD`
* `SORTINGHAT_DB_DATABASE`
* `SORTINGHAT_DB_HOST`
* `SORTINGHAT_DB_PORT`

The names of the env vars follows the schema `APPNAME_SECTION_CONFIG`.

With this PR the usage of sortinghat for Docker or "cloud" envs is much easier.

See [12 Fractured Apps](https://medium.com/@kelseyhightower/12-fractured-apps-1080c73d481c#.dothyjoc9) for further read.