### PR TITLE
Fix #35: [cmd:profile] Support specific error codes on Profile command

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -410,7 +410,7 @@ def edit_profile(db, uuid, **kwargs):
             is_bot = kwargs['is_bot']
 
             if type(is_bot) != bool:
-                raise ValueError('is_bot must have a boolean value')
+                raise WrappedValueError('is_bot must have a boolean value')
 
             profile.is_bot = is_bot
 

--- a/sortinghat/cmd/profile.py
+++ b/sortinghat/cmd/profile.py
@@ -27,7 +27,7 @@ import argparse
 
 from .. import api
 from ..command import Command, CMD_SUCCESS, CMD_FAILURE
-from ..exceptions import NotFoundError
+from ..exceptions import NotFoundError, WrappedValueError
 
 
 PROFILE_COMMAND_USAGE_MSG = \
@@ -107,9 +107,9 @@ class Profile(Command):
             uid = api.unique_identities(self.db, uuid)[0]
 
             self.display('profile.tmpl', uid=uid)
-        except (NotFoundError, ValueError) as e:
+        except (NotFoundError, WrappedValueError) as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS
 

--- a/tests/test_cmd_profile.py
+++ b/tests/test_cmd_profile.py
@@ -31,10 +31,11 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.profile import Profile
 from sortinghat.db.database import Database
 from sortinghat.db.model import Country
+from sortinghat.exceptions import CODE_NOT_FOUND_ERROR
 
 from tests.config import DB_USER, DB_PASSWORD, DB_NAME, DB_HOST, DB_PORT
 
@@ -131,7 +132,7 @@ class TestProfileCommand(TestBaseCase):
         """Check whether it raises an error when the uiid is not available"""
 
         code = self.cmd.run('FFFFFFFFFFFFFFF')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, PROFILE_UUID_NOT_FOUND_ERROR)
 
@@ -139,7 +140,7 @@ class TestProfileCommand(TestBaseCase):
         """Check whether it raises an error when the code country is not available"""
 
         code = self.cmd.run('52e0aa0a14826627e633fd15332988686b730ab3', '--country', 'ES')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, PROFILE_COUNTRY_NOT_FOUND_ERROR)
 


### PR DESCRIPTION
See https://github.com/MetricsGrimoire/sortinghat/issues/35