### PR TITLE
Fix #38: [cmd:unify] Support specific error codes on Unify command

### DIFF
--- a/sortinghat/cmd/unify.py
+++ b/sortinghat/cmd/unify.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
+from ..command import Command, CMD_SUCCESS
 from ..exceptions import MatcherNotSupportedError
 from ..matcher import create_identity_matcher, match
 from ..matching import SORTINGHAT_IDENTITIES_MATCHERS
@@ -101,7 +101,7 @@ class Unify(Command):
             matcher = create_identity_matcher(matching, blacklist)
         except MatcherNotSupportedError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         uidentities = api.unique_identities(self.db)
 

--- a/tests/test_cmd_unify.py
+++ b/tests/test_cmd_unify.py
@@ -31,9 +31,10 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.unify import Unify
 from sortinghat.db.database import Database
+from sortinghat.exceptions import CODE_MATCHER_NOT_SUPPORTED_ERROR
 
 from tests.config import DB_USER, DB_PASSWORD, DB_NAME, DB_HOST, DB_PORT
 
@@ -233,7 +234,7 @@ class TestUnify(TestBaseCase):
         """Check if it fails when an invalid matching method is given"""
 
         code = self.cmd.unify(matching='mock')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_MATCHER_NOT_SUPPORTED_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, UNIFY_MATCHING_ERROR)
 


### PR DESCRIPTION
See https://github.com/MetricsGrimoire/sortinghat/issues/38