### PR TITLE
Fix #39: [cmd:withdraw] Support specific error codes on Withdraw command

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -580,12 +580,12 @@ def delete_enrollment(db, uuid, organization, from_date=None, to_date=None):
         to_date = MAX_PERIOD_DATE
 
     if from_date < MIN_PERIOD_DATE or from_date > MAX_PERIOD_DATE:
-        raise ValueError('start date %s is out of bounds' % str(from_date))
+        raise WrappedValueError('start date %s is out of bounds' % str(from_date))
     if to_date < MIN_PERIOD_DATE or to_date > MAX_PERIOD_DATE:
-        raise ValueError('end date %s is out of bounds' % str(to_date))
+        raise WrappedValueError('end date %s is out of bounds' % str(to_date))
 
     if from_date > to_date:
-        raise ValueError('start date %s cannot be greater than %s'
+        raise WrappedValueError('start date %s cannot be greater than %s'
                          % (from_date, to_date))
 
     with db.connect() as session:

--- a/sortinghat/cmd/withdraw.py
+++ b/sortinghat/cmd/withdraw.py
@@ -26,8 +26,8 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api, utils
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
-from ..exceptions import InvalidDateError, NotFoundError
+from ..command import Command, CMD_SUCCESS
+from ..exceptions import InvalidDateError, NotFoundError, WrappedValueError
 
 
 class Withdraw(Command):
@@ -87,7 +87,7 @@ class Withdraw(Command):
             code = self.withdraw(uuid, organization, from_date, to_date)
         except InvalidDateError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return code
 
@@ -115,8 +115,8 @@ class Withdraw(Command):
 
         try:
             api.delete_enrollment(self.db, uuid, organization, from_date, to_date)
-        except (NotFoundError, ValueError) as e:
+        except (NotFoundError, WrappedValueError) as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS

--- a/tests/test_cmd_withdraw.py
+++ b/tests/test_cmd_withdraw.py
@@ -32,9 +32,10 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.withdraw import Withdraw
 from sortinghat.db.database import Database
+from sortinghat.exceptions import CODE_INVALID_DATE_ERROR, CODE_NOT_FOUND_ERROR, CODE_VALUE_ERROR
 
 from tests.config import DB_USER, DB_PASSWORD, DB_NAME, DB_HOST, DB_PORT
 
@@ -150,25 +151,25 @@ class TestWithdrawCommand(TestBaseCase):
 
         code = self.cmd.run('--from', '1999-13-01',
                             'John Smith', 'Example')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[0]
         self.assertEqual(output, WITHDRAW_INVALID_DATE_ERROR)
 
         code = self.cmd.run('--from', 'YYZYY',
                             'John Smith', 'Example')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[1]
         self.assertEqual(output, WITHDRAW_INVALID_FORMAT_DATE_ERROR)
 
         code = self.cmd.run('--to', '1999-13-01',
                             'John Smith', 'Example')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[2]
         self.assertEqual(output, WITHDRAW_INVALID_DATE_ERROR)
 
         code = self.cmd.run('--to', 'YYZYY',
                             'John Smith', 'Example')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[3]
         self.assertEqual(output, WITHDRAW_INVALID_FORMAT_DATE_ERROR)
 
@@ -237,7 +238,7 @@ class TestWithdraw(TestBaseCase):
         code = self.cmd.withdraw('John Smith', 'Example',
                                  datetime.datetime(2001, 1, 1),
                                  datetime.datetime(1999, 1, 1))
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_VALUE_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, WITHDRAW_INVALID_PERIOD_ERROR)
 
@@ -245,7 +246,7 @@ class TestWithdraw(TestBaseCase):
         """Check if it fails removing enrollments from unique identities that do not exist"""
 
         code = self.cmd.withdraw('Jane Roe', 'Example')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, WITHDRAW_UUID_NOT_FOUND_ERROR)
 
@@ -253,7 +254,7 @@ class TestWithdraw(TestBaseCase):
         """Check if it fails removing enrollments from organizations that do not exist"""
 
         code = self.cmd.withdraw('John Smith', 'LibreSoft')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, WITHDRAW_ORG_NOT_FOUND_ERROR)
 
@@ -264,7 +265,7 @@ class TestWithdraw(TestBaseCase):
         code = self.cmd.withdraw('John Doe', 'Bitergia',
                                  datetime.datetime(2050, 1, 1),
                                  datetime.datetime(2070, 1, 1))
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, WITHDRAW_ENROLLMENT_NOT_FOUND_ERROR)
 


### PR DESCRIPTION
See https://github.com/MetricsGrimoire/sortinghat/issues/39