### PR TITLE
Fix #31: [cmd:log] Support specific error codes on Log command

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -1196,12 +1196,12 @@ def enrollments(db, uuid=None, organization=None, from_date=None, to_date=None):
         to_date = MAX_PERIOD_DATE
 
     if from_date < MIN_PERIOD_DATE or from_date > MAX_PERIOD_DATE:
-        raise ValueError('start date %s is out of bounds' % str(from_date))
+        raise WrappedValueError('start date %s is out of bounds' % str(from_date))
     if to_date < MIN_PERIOD_DATE or to_date > MAX_PERIOD_DATE:
-        raise ValueError('end date %s is out of bounds' % str(to_date))
+        raise WrappedValueError('end date %s is out of bounds' % str(to_date))
 
     if from_date and to_date and from_date > to_date:
-        raise ValueError('start date %s cannot be greater than %s'
+        raise WrappedValueError('start date %s cannot be greater than %s'
                          % (from_date, to_date))
 
     enrollments = []

--- a/sortinghat/cmd/log.py
+++ b/sortinghat/cmd/log.py
@@ -26,8 +26,8 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api, utils
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
-from ..exceptions import InvalidDateError, NotFoundError
+from ..command import Command, CMD_SUCCESS
+from ..exceptions import InvalidDateError, NotFoundError, WrappedValueError
 
 
 class Log(Command):
@@ -85,7 +85,7 @@ class Log(Command):
             code = self.log(uuid, organization, from_date, to_date)
         except InvalidDateError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return code
 
@@ -114,8 +114,8 @@ class Log(Command):
             enrollments = api.enrollments(self.db, uuid, organization,
                                           from_date, to_date)
             self.display('log.tmpl', enrollments=enrollments)
-        except (NotFoundError, ValueError) as e:
+        except (NotFoundError, WrappedValueError) as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS

--- a/tests/test_cmd_log.py
+++ b/tests/test_cmd_log.py
@@ -32,9 +32,10 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.log import Log
 from sortinghat.db.database import Database
+from sortinghat.exceptions import CODE_INVALID_DATE_ERROR, CODE_VALUE_ERROR, CODE_NOT_FOUND_ERROR
 
 from tests.config import DB_USER, DB_PASSWORD, DB_NAME, DB_HOST, DB_PORT
 
@@ -169,22 +170,22 @@ class TestLogCommand(TestBaseCase):
         """Check whether it fails when invalid dates are given"""
 
         code = self.cmd.run('--from', '1999-13-01')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[0]
         self.assertEqual(output, LOG_INVALID_DATE_ERROR)
 
         code = self.cmd.run('--from', 'YYZYY')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[1]
         self.assertEqual(output, LOG_INVALID_FORMAT_DATE_ERROR)
 
         code = self.cmd.run('--to', '1999-13-01')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[2]
         self.assertEqual(output, LOG_INVALID_DATE_ERROR)
 
         code = self.cmd.run('--to', 'YYZYY')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_DATE_ERROR)
         output = sys.stderr.getvalue().strip('\n').split('\n')[3]
         self.assertEqual(output, LOG_INVALID_FORMAT_DATE_ERROR)
 
@@ -231,7 +232,7 @@ class TestLog(TestBaseCase):
         code = self.cmd.log('John Smith', 'Example',
                             datetime.datetime(2001, 1, 1),
                             datetime.datetime(1999, 1, 1))
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_VALUE_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, LOG_INVALID_PERIOD_ERROR)
 
@@ -239,7 +240,7 @@ class TestLog(TestBaseCase):
         """Check whether it raises an error when the uiid is not available"""
 
         code = self.cmd.log(uuid='Jane Roe')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, LOG_UUID_NOT_FOUND_ERROR)
 
@@ -247,7 +248,7 @@ class TestLog(TestBaseCase):
         """Check whether it raises an error when the organization is not available"""
 
         code = self.cmd.log(organization='LibreSoft')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, LOG_ORG_NOT_FOUND_ERROR)
 


### PR DESCRIPTION
See https://github.com/MetricsGrimoire/sortinghat/issues/31