### PR TITLE
Fix #24: [cmd:blacklist] Support specific error codes on Blacklist command

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -356,9 +356,9 @@ def add_to_matching_blacklist(db, entity):
         in the registry.
     """
     if entity is None:
-        raise ValueError('entity to blacklist cannot be None')
+        raise WrappedValueError('entity to blacklist cannot be None')
     if entity == '':
-        raise ValueError('entity to blacklist cannot be an empty string')
+        raise WrappedValueError('entity to blacklist cannot be an empty string')
 
     with db.connect() as session:
         mb = session.query(MatchingBlacklist).\

--- a/sortinghat/cmd/blacklist.py
+++ b/sortinghat/cmd/blacklist.py
@@ -26,8 +26,8 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
-from ..exceptions import AlreadyExistsError, NotFoundError
+from ..command import Command, CMD_SUCCESS
+from ..exceptions import AlreadyExistsError, NotFoundError, WrappedValueError
 
 
 BLACKLIST_COMMAND_USAGE_MSG = \
@@ -108,13 +108,13 @@ class Blacklist(Command):
 
         try:
             api.add_to_matching_blacklist(self.db, entry)
-        except ValueError as e:
+        except WrappedValueError as e:
             # If the code reaches here, something really wrong has happened
             # because entry cannot be None or empty
             raise RuntimeError(str(e))
         except AlreadyExistsError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS
 
@@ -132,7 +132,7 @@ class Blacklist(Command):
             api.delete_from_matching_blacklist(self.db, entry)
         except NotFoundError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS
 
@@ -150,6 +150,6 @@ class Blacklist(Command):
             self.display('blacklist.tmpl', blacklist=bl)
         except NotFoundError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS

--- a/tests/test_cmd_blacklist.py
+++ b/tests/test_cmd_blacklist.py
@@ -31,10 +31,10 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.blacklist import Blacklist
 from sortinghat.db.database import Database
-from sortinghat.exceptions import NotFoundError
+from sortinghat.exceptions import NotFoundError, CODE_ALREADY_EXISTS_ERROR, CODE_NOT_FOUND_ERROR
 
 from tests.config import DB_USER, DB_PASSWORD, DB_NAME, DB_HOST, DB_PORT
 
@@ -250,7 +250,7 @@ class TestAdd(unittest.TestCase):
         self.assertEqual(code, CMD_SUCCESS)
 
         code = self.cmd.add('root@example.com')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_ALREADY_EXISTS_ERROR)
 
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, BLACKLIST_ALREADY_EXISTS_ERROR)
@@ -341,7 +341,7 @@ class TestDelete(unittest.TestCase):
 
         # It should print an error when the blacklist is empty
         code = self.cmd.delete('root@example.net')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[0]
         self.assertEqual(output, BLACKLIST_NOT_FOUND_ERROR)
 
@@ -352,7 +352,7 @@ class TestDelete(unittest.TestCase):
 
         # The error should be the same
         code = self.cmd.delete('root@example.net')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[1]
         self.assertEqual(output, BLACKLIST_NOT_FOUND_ERROR)
 
@@ -406,7 +406,7 @@ class TestBlacklist(unittest.TestCase):
         """Check whether it prints an error for not existing entries"""
 
         code = self.cmd.blacklist('root@example.net')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_NOT_FOUND_ERROR)
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, BLACKLIST_NOT_FOUND_ERROR)
 


### PR DESCRIPTION
See https://github.com/MetricsGrimoire/sortinghat/issues/24