### PR TITLE
Fix #30: [cmd:load] Support specific error codes on Load command

### DIFF
--- a/sortinghat/cmd/load.py
+++ b/sortinghat/cmd/load.py
@@ -27,7 +27,7 @@ import argparse
 import sys
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
+from ..command import Command, CMD_SUCCESS
 from ..db.model import MIN_PERIOD_DATE, MAX_PERIOD_DATE
 from ..exceptions import AlreadyExistsError, NotFoundError,\
     InvalidFormatError, LoadError, MatcherNotSupportedError
@@ -129,7 +129,7 @@ class Load(Command):
                 parser = SortingHatParser(stream)
             except InvalidFormatError as e:
                 self.error(str(e))
-                return CMD_FAILURE
+                return e.code
             except (IOError, TypeError, AttributeError) as e:
                 raise RuntimeError(str(e))
 
@@ -234,7 +234,7 @@ class Load(Command):
                 matcher = create_identity_matcher(matching, blacklist)
             except MatcherNotSupportedError as e:
                 self.error(str(e))
-                return CMD_FAILURE
+                return e.code
 
         uidentities = parser.identities
 
@@ -243,7 +243,7 @@ class Load(Command):
                                           verbose)
         except LoadError as e:
             self.error(str(e))
-            return CMD_FAILURE
+            return e.code
 
         return CMD_SUCCESS
 

--- a/tests/test_cmd_load.py
+++ b/tests/test_cmd_load.py
@@ -33,11 +33,12 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.load import Load
 from sortinghat.db.database import Database
 from sortinghat.db.model import Country
 from sortinghat.parsing.sh import SortingHatParser
+from sortinghat.exceptions import CODE_MATCHER_NOT_SUPPORTED_ERROR, CODE_INVALID_FORMAT_ERROR
 
 from tests.config import DB_USER, DB_PASSWORD, DB_NAME, DB_HOST, DB_PORT
 
@@ -198,7 +199,7 @@ class TestLoadCommand(TestBaseCase):
         """Test whether it prints error messages while reading invalid files"""
 
         code = self.cmd.run('--identities', 'data/sortinghat_invalid.json')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[0]
         self.assertEqual(output, LOAD_IDENTITIES_INVALID_JSON_FORMAT_ERROR)
 
@@ -233,34 +234,34 @@ class TestLoadCommand(TestBaseCase):
         """Check whether it prints an error when parsing invalid files"""
 
         code = self.cmd.run('data/sortinghat_invalid.json')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[0]
         self.assertEqual(output, LOAD_IDENTITIES_INVALID_JSON_FORMAT_ERROR)
 
         code = self.cmd.run('data/sortinghat_ids_missing_keys.json')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[1]
         self.assertEqual(output, LOAD_IDENTITIES_MISSING_KEYS_ERROR)
 
         # Context added to catch deprecation warnings raised on Python 3
         with warnings.catch_warnings(record=True):
             code = self.cmd.run('data/sortinghat_orgs_invalid_json.json')
-            self.assertEqual(code, CMD_FAILURE)
+            self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
             output = sys.stderr.getvalue().strip().split('\n')[2]
             self.assertRegexpMatches(output, LOAD_ORGS_INVALID_FORMAT_ERROR)
 
         code = self.cmd.run('data/sortinghat_orgs_missing_keys.json')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[3]
         self.assertEqual(output, LOAD_ORGS_MISSING_KEYS_ERROR)
 
         code = self.cmd.run('data/sortinghat_orgs_invalid_top.json')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[4]
         self.assertEqual(output, LOAD_ORGS_IS_TOP_ERROR)
 
         code = self.cmd.run('data/sortinghat_blacklist_empty_strings.json')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[5]
         self.assertEqual(output, LOAD_BLACKLIST_EMPTY_STRINGS_ERROR)
 
@@ -711,7 +712,7 @@ class TestLoadIdentities(TestBaseCase):
         parser = self.get_parser('data/sortinghat_valid.json')
 
         code = self.cmd.import_identities(parser, matching='mock')
-        self.assertEqual(code, CMD_FAILURE)
+        self.assertEqual(code, CODE_MATCHER_NOT_SUPPORTED_ERROR)
 
         output = sys.stderr.getvalue().strip()
         self.assertEqual(output, LOAD_IDENTITIES_MATCHING_ERROR)


### PR DESCRIPTION
See https://github.com/MetricsGrimoire/sortinghat/issues/30