### PR TITLE
Remove unnecessary CMD_FAILURE import

### DIFF
--- a/sortinghat/cmd/move.py
+++ b/sortinghat/cmd/move.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
+from ..command import Command, CMD_SUCCESS
 from ..exceptions import NotFoundError
 
 

--- a/sortinghat/cmd/profile.py
+++ b/sortinghat/cmd/profile.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
+from ..command import Command, CMD_SUCCESS
 from ..exceptions import NotFoundError, WrappedValueError
 
 

--- a/sortinghat/cmd/remove.py
+++ b/sortinghat/cmd/remove.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
+from ..command import Command, CMD_SUCCESS
 from ..exceptions import NotFoundError
 
 

--- a/sortinghat/cmd/show.py
+++ b/sortinghat/cmd/show.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals
 import argparse
 
 from .. import api
-from ..command import Command, CMD_SUCCESS, CMD_FAILURE
+from ..command import Command, CMD_SUCCESS
 from ..exceptions import NotFoundError
 
 

--- a/tests/test_cmd_add.py
+++ b/tests/test_cmd_add.py
@@ -31,7 +31,7 @@ if not '..' in sys.path:
     sys.path.insert(0, '..')
 
 from sortinghat import api
-from sortinghat.command import CMD_SUCCESS, CMD_FAILURE
+from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.add import Add
 from sortinghat.db.database import Database
 from sortinghat.exceptions import CODE_ALREADY_EXISTS_ERROR, CODE_MATCHER_NOT_SUPPORTED_ERROR, CODE_NOT_FOUND_ERROR, CODE_VALUE_ERROR


### PR DESCRIPTION
During the "Error Codes" changes we left some unnecessary imports in some commands of `CMD_FAILURE` constant.

This PR removes it.

We leave the original `CMD_FAILURE` definition there, but this is (currently) not in use.