### PR TITLE
Bugfix for usage with Docker / Database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can use our image from [DockerHub](https://hub.docker.com/r/metricsgrimoire/
 If you prefer to build the image yourself execute:
 
 ```sh
-$ docker build -t metricsgrimoire/sortinghat:latest .
+$ docker build -t metricsgrimoire/sortinghat .
 ```
 
 Next step would be to start a MySQL docker container for data storage:
@@ -97,7 +97,7 @@ Run the sortinghat docker container in interactive mode:
 
 ```sh
 $ docker run -i -t --rm \
-             --link mysql:mysql metricsgrimoire/sortinghat:latest \
+             --link mysql:mysql metricsgrimoire/sortinghat \
              /bin/bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Next step would be to start a MySQL docker container for data storage:
 
 ```sh
 $ docker run --name mysql \
-             -e MYSQL_USER=sortinghat \
-             -e MYSQL_PASSWORD=sortinghat \
              -e MYSQL_ROOT_PASSWORD=sortinghat \
              -d mysql
 ```
@@ -97,11 +95,22 @@ Run the sortinghat docker container in interactive mode:
 
 ```sh
 $ docker run -i -t --rm \
-             --link mysql:mysql metricsgrimoire/sortinghat \
+             --link mysql:mysql \
+             -e SORTINGHAT_DB_HOST=mysql \
+             -e SORTINGHAT_DB_PASSWORD=sortinghat \
+             -e SORTINGHAT_DB_DATABASE=sortinghat \
+             metricsgrimoire/sortinghat \
              /bin/bash
 ```
 
-You are ready to use sortinghat!
+Now you can initialize sortinghat with the database name `sortinghat`:
+
+```
+$ sortinghat init sortinghat
+```
+
+You are ready to use sortinghat and explore the commands documented below. 
+Have fun!
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ You are ready to use sortinghat!
 
 ### Docker
 
-At first you need to build the image:
+You can use our image from [DockerHub](https://hub.docker.com/r/metricsgrimoire/sortinghat/) (`metricsgrimoire/sortinghat`) and skip the `docker build` step.
+If you prefer to build the image yourself execute:
 
 ```sh
 $ docker build -t metricsgrimoire/sortinghat:latest .

--- a/bin/sortinghat
+++ b/bin/sortinghat
@@ -143,8 +143,8 @@ def create_common_arguments_parser(defaults):
                        help=argparse.SUPPRESS)
     group.add_argument('-p', '--password', dest='password', default=os.getenv('SORTINGHAT_DB_PASSWORD', ''),
                        help=argparse.SUPPRESS)
-    group.add_argument('-d', '--database', dest=os.getenv('SORTINGHAT_DB_DATABASE', 'database'),
-                       help=argparse.SUPPRESS)
+    group.add_argument('-d', '--database', dest='database', default=os.getenv('SORTINGHAT_DB_DATABASE', ''),
+                         help=argparse.SUPPRESS)
     group.add_argument('--host', dest='host', default=os.getenv('SORTINGHAT_DB_HOST', 'localhost'),
                        help=argparse.SUPPRESS)
     group.add_argument('--port', dest='port', default=os.getenv('SORTINGHAT_DB_PORT', '3306'),


### PR DESCRIPTION
In https://github.com/MetricsGrimoire/sortinghat/commit/fd751437f115ae4c2511249cf73e9491b1b88d38 i broke the configuration "database".
I set `dest` instead of `default` attribute for the env var assignment.

If i set the env var `` the attribute "database" is not existing and leads to 
```
$ bin/sortinghat init sortinghat
Traceback (most recent call last):
  File "bin/sortinghat", line 181, in <module>
    code = main()
  File "bin/sortinghat", line 91, in main
    database=args.database, host=args.host,
AttributeError: 'Namespace' object has no attribute 'database'
```

`args` in this case is
```
Namespace(cmd_args=['sortinghat'], command='init', host='mysql', password='sortinghat', port=u'3306', sortinghat=None, user=u'root')
```

You see the `sortinghat=None`? Expected value is `database=sortinghat`.
This PR fixes this issue.

Next to this bugfix i adjusted the docker commands describes in the README to make use of the env vars and tested it again with the latest changes.
Now sortinghat is able to use with docker.

Sorry for this issue :(