### PR TITLE
[matchers] Add Username matcher.

### DIFF
--- a/sortinghat/matching/__init__.py
+++ b/sortinghat/matching/__init__.py
@@ -25,10 +25,12 @@ from __future__ import unicode_literals
 
 from .email import EmailMatcher
 from .email_name import EmailNameMatcher
+from .username import UsernameMatcher
 
 
 SORTINGHAT_IDENTITIES_MATCHERS = {
                                   'default'    : EmailMatcher,
                                   'email'      : EmailMatcher,
                                   'email-name' : EmailNameMatcher,
+                                  'username'   : UsernameMatcher
                                   }

--- a/sortinghat/matching/username.py
+++ b/sortinghat/matching/username.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import re
+
+from ..db.model import UniqueIdentity
+from ..matcher import IdentityMatcher, FilteredIdentity
+
+
+class UsernameIdentity(FilteredIdentity):
+    """Class to stored Username filtered identities"""
+
+    def __init__(self, id, uuid, username):
+        super(UsernameIdentity, self).__init__(id, uuid)
+        self.username = username
+
+    def to_dict(self):
+        return {
+                'id'    : self.id,
+                'uuid'  : self.uuid,
+                'username' : self.username
+               }
+
+
+class UsernameMatcher(IdentityMatcher):
+    """
+    Simple unique identities matcher.
+
+    This matcher only produces a positive result when two identities
+    from each unique identity share the same username. It also
+    returns a positive match when the uuid on both unique identities is equal.
+
+    :param blacklist: list of entries to ignore during the matching process
+    """
+    def __init__(self, blacklist=[]):
+        super(UsernameMatcher, self).__init__(blacklist=blacklist)
+
+    def match(self, a, b):
+        """Determine if two unique identities are the same.
+
+        This method compares the username of each identity to check
+        if the given unique identities are the same. When the given unique
+        identities are the same object or share the same UUID, this will
+        also produce a positive match.
+
+        Identities which their username are in the blacklist will be
+        ignored and the result of the comparison will be false.
+
+        :param a: unique identity to match
+        :param b: unique identity to match
+
+        :returns: True when both unique identities are likely to be the same.
+            Otherwise, returns False.
+
+        :raises ValueError: when any of the given unique identities is not
+            an instance of UniqueIdentity class
+        """
+        if not isinstance(a, UniqueIdentity):
+            raise ValueError("<a> is not an instance of UniqueIdentity")
+        if not isinstance(b, UniqueIdentity):
+            raise ValueError("<b> is not an instance of UniqueIdentity")
+
+        if a.uuid and b.uuid and a.uuid == b.uuid:
+            return True
+
+        usernames_a = self._filter_usernames(a.identities)
+        usernames_b = self._filter_usernames(b.identities)
+
+        for username in usernames_a:
+            if username in usernames_b:
+                return True
+        return False
+
+    def match_filtered_identities(self, fa, fb):
+        """Determine if two filtered identities are the same.
+
+        The method compares the username of each filtered identity
+        to check if they are the same. When the given filtered identities
+        are the same object or share the same UUID, this will also
+        produce a positive match.
+
+        Identities which their username are in the blacklist will be
+        ignored and the result of the comparison will be false.
+
+        :param fa: filtered identity to match
+        :param fb: filtered identity to match
+
+        :returns: True when both filtered identities are likely to be the same.
+            Otherwise, returns False.
+
+        :raises ValueError: when any of the given filtered identities is not
+            an instance of UsernameIdentity class.
+        """
+        if not isinstance(fa, UsernameIdentity):
+            raise ValueError("<fa> is not an instance of UsernameIdentity")
+        if not isinstance(fb, UsernameIdentity):
+            raise ValueError("<fb> is not an instance of UsernameIdentity")
+
+        if fa.uuid and fb.uuid and fa.uuid == fb.uuid:
+            return True
+
+        if fa.username in self.blacklist:
+            return False
+
+        # Compare username first
+        if fa.username and fa.username == fb.username:
+            return True
+
+        return False
+
+    def filter(self, u):
+        """Filter the valid identities for this matcher.
+
+        :param u: unique identity which stores the identities to filter
+
+        :returns: a list of identities valid to work with this matcher.
+
+        :raises ValueError: when the unique identity is not an instance
+            of UniqueIdentity class
+        """
+        if not isinstance(u, UniqueIdentity):
+            raise ValueError("<u> is not an instance of UniqueIdentity")
+
+        filtered = []
+
+        for id_ in u.identities:
+            username = None
+
+            if self._check_username(id_.username):
+                username = id_.username.lower()
+
+            if username:
+                fid = UsernameIdentity(id_.id, id_.uuid, username)
+                filtered.append(fid)
+
+        return filtered
+
+    @staticmethod
+    def matching_criteria():
+        """List of keys used during the matching phase.
+
+        returns: a list of keys
+        """
+        return ['username']
+
+    def _filter_usernames(self, ids):
+        return [id_.username.lower() for id_ in ids \
+                if self._check_username(id_.username)]
+
+    def _check_username(self, username):
+        if not username:
+            return False
+        elif username.lower() in self.blacklist:
+            return False
+        return True

--- a/tests/test_matcher_username.py
+++ b/tests/test_matcher_username.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2015 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#
+
+from __future__ import unicode_literals
+
+import sys
+import unittest
+
+if not '..' in sys.path:
+    sys.path.insert(0, '..')
+
+from sortinghat.db.model import UniqueIdentity, Identity, MatchingBlacklist
+from sortinghat.matching.username import UsernameMatcher, UsernameIdentity
+
+
+class TestUsernameMatcher(unittest.TestCase):
+
+    def test_match(self):
+        """Test match method"""
+
+        # Let's define some identities first
+        jsmith = UniqueIdentity(uuid='jsmith')
+        jsmith.identities = [Identity(name='John Smith', email='jsmith@example.com', source='scm'),
+                             Identity(name='John Smith', source='scm'),
+                             Identity(username='jsmith', source='scm'),
+                             Identity(email='', source='scm')]
+
+        john_smith = UniqueIdentity(uuid='js')
+        john_smith.identities = [Identity(name='J. Smith', username='john_smith', source='scm'),
+                                 Identity(username='john_smith', source='scm'),
+                                 Identity(name='Smith. J', source='mls'),
+                                 Identity(name='Smith. J', email='JSmith@example.com', source='mls')]
+
+        jsmith_alt = UniqueIdentity(uuid='J. Smith')
+        jsmith_alt.identities = [Identity(name='J. Smith', username='john_smith', source='alt'),
+                                 Identity(name='John Smith', username='jsmith', source='alt'),
+                                 Identity(email='', source='alt'),
+                                 Identity(email='jsmith', source='alt')]
+
+        # Tests
+        matcher = UsernameMatcher()
+
+        # First two unique does not produce any match
+        result = matcher.match(jsmith, john_smith)
+        self.assertEqual(result, False)
+
+        result = matcher.match(john_smith, jsmith)
+        self.assertEqual(result, False)
+
+        # Comparing the third match with the second
+        result = matcher.match(jsmith, jsmith_alt)
+        self.assertEqual(result, True)
+
+        result = matcher.match(jsmith_alt, jsmith)
+        self.assertEqual(result, True)
+
+        result = matcher.match(john_smith, jsmith_alt)
+        self.assertEqual(result, True)
+
+        result = matcher.match(jsmith_alt, john_smith)
+        self.assertEqual(result, True)
+
+
+    def test_match_with_blacklist(self):
+        """Test match when there are entries in the blacklist"""
+
+        # Let's define some identities first
+        jsmith = UniqueIdentity(uuid='jsmith')
+        jsmith.identities = [Identity(name='John Smith', username='John_Smith', source='scm'),
+                             Identity(name='John Smith', source='scm'),
+                             Identity(username='jsmith', source='scm'),
+                             Identity(email='', source='scm')]
+
+        john_smith = UniqueIdentity(uuid='js')
+        john_smith.identities = [Identity(name='J. Smith', email='JSmith@example.com',  source='scm'),
+                                 Identity(username='john_smith', source='scm'),
+                                 Identity(name='Smith. J', source='mls'),
+                                 Identity(name='Smith. J', username='john_smith', source='mls')]
+
+        jrae = UniqueIdentity(uuid='jrae')
+        jrae.identities = [Identity(name='Jane Rae', source='scm', uuid='jrae'),
+                           Identity(name='Jane Rae Doe', username='jane.rae', email='jane.rae@example.net', source='mls', uuid='jrae'),
+                           Identity(name='jrae', source='scm', uuid='jrae'),
+                           Identity(email='JRAE@example.net', source='scm', uuid='jrae')]
+
+        jane_rae = UniqueIdentity(uuid='Jane Rae')
+        jane_rae.identities = [Identity(name='Jane Rae', source='scm', uuid='Jane Rae'),
+                               Identity(email='jrae@example.net', username='Jane.rae', source='mls', uuid='Jane Rae')]
+
+        # Check matching
+        matcher = UsernameMatcher()
+
+        # First two unique identities must match
+        result = matcher.match(jsmith, john_smith)
+        self.assertEqual(result, True)
+
+        result = matcher.match(john_smith, jsmith)
+        self.assertEqual(result, True)
+
+        result = matcher.match(jrae, jane_rae)
+        self.assertEqual(result, True)
+
+        result = matcher.match(jane_rae, jrae)
+        self.assertEqual(result, True)
+
+        # Add a blacklist
+        bl = [MatchingBlacklist(excluded='john_smith')]
+
+        matcher = UsernameMatcher(blacklist=bl)
+
+        result = matcher.match(jsmith, john_smith)
+        self.assertEqual(result, False)
+
+        result = matcher.match(john_smith, jsmith)
+        self.assertEqual(result, False)
+
+        result = matcher.match(jrae, jane_rae)
+        self.assertEqual(result, True)
+
+        result = matcher.match(jane_rae, jrae)
+        self.assertEqual(result, True)
+
+        # In this case, no match will be found
+        bl = [MatchingBlacklist(excluded='John_Smith'),
+              MatchingBlacklist(excluded='Jane.rae')]
+
+        matcher = UsernameMatcher(blacklist=bl)
+
+        result = matcher.match(jsmith, john_smith)
+        self.assertEqual(result, False)
+
+        result = matcher.match(john_smith, jsmith)
+        self.assertEqual(result, False)
+
+        result = matcher.match(jrae, jane_rae)
+        self.assertEqual(result, False)
+
+        result = matcher.match(jane_rae, jrae)
+        self.assertEqual(result, False)
+
+    def test_match_same_identity(self):
+        """Test whether there is a match comparing the same identity"""
+
+        uid = UniqueIdentity(uuid='John Smith')
+
+        matcher = UsernameMatcher()
+        result = matcher.match(uid, uid)
+
+        self.assertEqual(result, True)
+
+    def test_match_same_uuid(self):
+        """Test if there is a match when compares identities with the same UUID"""
+
+        uid1 = UniqueIdentity(uuid='John Smith')
+        uid2 = UniqueIdentity(uuid='John Smith')
+
+        matcher = UsernameMatcher()
+
+        result = matcher.match(uid1, uid2)
+        self.assertEqual(result, True)
+
+        result = matcher.match(uid2, uid1)
+        self.assertEqual(result, True)
+
+        uid1 = UniqueIdentity(uuid=None)
+        uid2 = UniqueIdentity(uuid=None)
+
+        result = matcher.match(uid1, uid2)
+        self.assertEqual(result, False)
+
+    def test_match_identities_instances(self):
+        """Test whether it raises an error when ids are not UniqueIdentities"""
+
+        uid = UniqueIdentity(uuid='John Smith')
+
+        matcher = UsernameMatcher()
+
+        self.assertRaises(ValueError, matcher.match, 'John Smith', uid)
+        self.assertRaises(ValueError, matcher.match, uid, 'John Smith')
+        self.assertRaises(ValueError, matcher.match, None, uid)
+        self.assertRaises(ValueError, matcher.match, uid, None)
+        self.assertRaises(ValueError, matcher.match, 'John Smith', 'John Doe')
+
+    def test_match_filtered_identities(self):
+        """Test whether filtered identities match"""
+
+        jsmith = UsernameIdentity('1', None, 'jsmith')
+        jsmith_alt = UsernameIdentity('2', 'jsmith', 'jsmith')
+        jsmith_uuid = UsernameIdentity('3', 'jsmith', 'john.smith')
+
+        matcher = UsernameMatcher()
+
+        result = matcher.match_filtered_identities(jsmith, jsmith_alt)
+        self.assertEqual(result, True)
+
+        result = matcher.match_filtered_identities(jsmith, jsmith_uuid)
+        self.assertEqual(result, False)
+
+        result = matcher.match_filtered_identities(jsmith_alt, jsmith)
+        self.assertEqual(result, True)
+
+        result = matcher.match_filtered_identities(jsmith_alt, jsmith_uuid)
+        self.assertEqual(result, True)
+
+        result = matcher.match_filtered_identities(jsmith_uuid, jsmith)
+        self.assertEqual(result, False)
+
+        result = matcher.match_filtered_identities(jsmith_uuid, jsmith_alt)
+        self.assertEqual(result, True)
+
+    def test_match_filtered_identities_with_blacklist(self):
+        """Test whether filtered identities match when there is a blacklist"""
+
+        jsmith = UsernameIdentity('1', None, 'jsmith')
+        jsmith_alt = UsernameIdentity('2', 'jsmith', 'jsmith')
+        jsmith_uuid = UsernameIdentity('3', 'jsmith', 'john.smith')
+        john_alt = UsernameIdentity('4', None, 'john.smith')
+        jsmith_none = UsernameIdentity('4', 'john.smith', None)
+        jdoe_none = UsernameIdentity('4', 'jdoe', None)
+
+        bl = [MatchingBlacklist(excluded='JSMITH')]
+
+        matcher = UsernameMatcher(blacklist=bl)
+
+        result = matcher.match_filtered_identities(jsmith, jsmith_alt)
+        self.assertEqual(result, False)
+
+        result = matcher.match_filtered_identities(jsmith, jsmith_uuid)
+        self.assertEqual(result, False)
+
+        result = matcher.match_filtered_identities(jsmith_alt, jsmith)
+        self.assertEqual(result, False)
+
+        # Same UUID
+        result = matcher.match_filtered_identities(jsmith_alt, jsmith_uuid)
+        self.assertEqual(result, True)
+
+        result = matcher.match_filtered_identities(jsmith_uuid, jsmith)
+        self.assertEqual(result, False)
+
+        # Same UUID
+        result = matcher.match_filtered_identities(jsmith_uuid, jsmith_alt)
+        self.assertEqual(result, True)
+
+        result = matcher.match_filtered_identities(jsmith_uuid, john_alt)
+        self.assertEqual(result, True)
+
+        result = matcher.match_filtered_identities(john_alt, jsmith_uuid)
+        self.assertEqual(result, True)
+
+        # Although the UUID is equal to None, these two does not match
+        result = matcher.match_filtered_identities(jsmith_none, jdoe_none)
+        self.assertEqual(result, False)
+
+    def test_match_filtered_identities_instances(self):
+        """Test whether it raises an error when ids are not UsernameIdentities"""
+
+        fid = UsernameIdentity('1', None, 'jsmith')
+
+        matcher = UsernameMatcher()
+
+        self.assertRaises(ValueError, matcher.match_filtered_identities, 'John Smith', fid)
+        self.assertRaises(ValueError, matcher.match_filtered_identities, fid, 'John Smith')
+        self.assertRaises(ValueError, matcher.match_filtered_identities, None, fid)
+        self.assertRaises(ValueError, matcher.match_filtered_identities, fid, None)
+        self.assertRaises(ValueError, matcher.match_filtered_identities, 'John Smith', 'John Doe')
+
+    def test_filter_identities(self):
+        """Test if identities are filtered"""
+
+        # Let's define some identities first
+        jsmith = UniqueIdentity(uuid='jsmith')
+        jsmith.identities = [Identity(name='John Smith', username='jsmith', source='scm', uuid='jsmith'),
+                             Identity(name='John Smith', source='scm', uuid='jsmith'),
+                             Identity(email='jsmith@example.com', source='scm', uuid='jsmith'),
+                             Identity(username='', source='scm', uuid='jsmith')]
+
+        jrae = UniqueIdentity(uuid='jrae')
+        jrae.identities = [Identity(name='Jane Rae', source='scm', uuid='jrae'),
+                           Identity(name='Jane Rae Doe', username='jane.rae', source='mls', uuid='jrae'),
+                           Identity(name='jrae', source='scm', uuid='jrae'),
+                           Identity(username='JRAE', source='scm', uuid='jrae')]
+
+        matcher = UsernameMatcher()
+
+        result = matcher.filter(jsmith)
+        self.assertEqual(len(result), 1)
+
+        fid = result[0]
+        self.assertIsInstance(fid, UsernameIdentity)
+        self.assertEqual(fid.uuid, 'jsmith')
+        self.assertEqual(fid.username, 'jsmith')
+
+        result = matcher.filter(jrae)
+        self.assertEqual(len(result), 2)
+
+        fid = result[0]
+        self.assertIsInstance(fid, UsernameIdentity)
+        self.assertEqual(fid.uuid, 'jrae')
+        self.assertEqual(fid.username, 'jane.rae')
+
+        fid = result[1]
+        self.assertIsInstance(fid, UsernameIdentity)
+        self.assertEqual(fid.uuid, 'jrae')
+        self.assertEqual(fid.username, 'jrae')
+
+    def test_filter_identities_with_blacklist(self):
+        """Test if identities are filtered when there is a blacklist"""
+
+        # Let's define some identities first
+        jsmith = UniqueIdentity(uuid='jsmith')
+        jsmith.identities = [Identity(name='John Smith', username='jsmith', source='scm', uuid='jsmith'),
+                             Identity(name='John Smith', source='scm', uuid='jsmith'),
+                             Identity(email='jsmith@example.com', source='scm', uuid='jsmith'),
+                             Identity(email='', source='scm', uuid='jsmith')]
+
+        jrae = UniqueIdentity(uuid='jrae')
+        jrae.identities = [Identity(name='Jane Rae', source='scm', uuid='jrae'),
+                           Identity(name='Jane Rae Doe', username='jane.rae', source='mls', uuid='jrae'),
+                           Identity(name='jrae', source='scm', uuid='jrae'),
+                           Identity(username='JRAE', source='scm', uuid='jrae')]
+
+        bl = [MatchingBlacklist(excluded='jrae')]
+
+        matcher = UsernameMatcher(blacklist=bl)
+
+        result = matcher.filter(jsmith)
+        self.assertEqual(len(result), 1)
+
+        fid = result[0]
+        self.assertIsInstance(fid, UsernameIdentity)
+        self.assertEqual(fid.uuid, 'jsmith')
+        self.assertEqual(fid.username, 'jsmith')
+
+        result = matcher.filter(jrae)
+        self.assertEqual(len(result), 1)
+
+        fid = result[0]
+        self.assertIsInstance(fid, UsernameIdentity)
+        self.assertEqual(fid.uuid, 'jrae')
+        self.assertEqual(fid.username, 'jane.rae')
+
+    def test_filter_identities_instances(self):
+        """Test whether it raises an error when id is not a UniqueIdentity"""
+
+        matcher = UsernameMatcher()
+
+        self.assertRaises(ValueError, matcher.filter, 'John Smith')
+        self.assertRaises(ValueError, matcher.filter, None)
+
+    def test_matching_criteria(self):
+        """Test whether it returns the matching criteria keys"""
+
+        criteria = UsernameMatcher.matching_criteria()
+
+        self.assertListEqual(criteria, ['username'])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented this matcher sto cover the use case in which we have usernames from GitHub and we use them to unify identities.